### PR TITLE
fix(docs): missing dependency in gh action

### DIFF
--- a/.github/workflows/mkdocs-gh-pages.yml
+++ b/.github/workflows/mkdocs-gh-pages.yml
@@ -24,5 +24,5 @@ jobs:
           path: ~/.cache 
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material 
+      - run: pip install mkdocs-material mkdocs-with-pdf
       - run: cd ./datenkraken-docs && mkdocs gh-deploy --force


### PR DESCRIPTION
hotfix to fix gh action from failing due to missing dependencies for building pdf.

since this seems to be the last change for our project ill use this branch for our submission